### PR TITLE
Refactoring to support flux 1.15

### DIFF
--- a/default/home-assistant/home-assistant.yaml
+++ b/default/home-assistant/home-assistant.yaml
@@ -1,15 +1,17 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: home-assistant
   namespace: default
   annotations:
     fluxcd.io/ignore: false
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.chart-image: semver:~0
+    fluxcd.io/automated: "true"
+    fluxcd.io/tag.chart-image: semver:~0
 spec:
   releaseName: home-assistant
+  rollback:
+    enable: true
   chart:
     repository: https://kubernetes-charts.storage.googleapis.com/
     name: home-assistant
@@ -20,7 +22,6 @@ spec:
       tag: 0.99.3
     persistence:
       enabled: true
-      # accessMode: ReadWriteOnce
       size: 10Gi
       storageClass: "rook-cephfs"
     ingress:
@@ -43,4 +44,3 @@ spec:
           nginx.ingress.kubernetes.io/auth-secret: "nginx-basic-auth-jeff"
   valueFileSecrets:
   - name: "home-assistant-helm-values"
-

--- a/default/home-assistant/postgresql.yaml
+++ b/default/home-assistant/postgresql.yaml
@@ -1,13 +1,13 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: hass-postgresql
   namespace: default
   annotations:
     fluxcd.io/ignore: false
-    flux.weave.works/automated: "false"
-    flux.weave.works/tag.chart-image: semver:~11
+    fluxcd.io: "false"
+    fluxcd.io: semver:~11
 spec:
   releaseName: hass-postgresql
   chart:

--- a/default/minio/minio.yaml
+++ b/default/minio/minio.yaml
@@ -1,13 +1,13 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: minio
   namespace: default
   annotations:
     fluxcd.io/ignore: false
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.chart-image: glob:RELEASE.*
+    fluxcd.io/automated: "true"
+    fluxcd.io/tag.chart-image: glob:RELEASE.*
 spec:
   releaseName: minio
   chart:

--- a/default/node-red/node-red.yaml
+++ b/default/node-red/node-red.yaml
@@ -1,14 +1,16 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: node-red
   namespace: default
   annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.chart-image: 'regexp:^(1\.[0-9]+\.[0-9]+-12-minimal)$'
+    fluxcd.io/automated: "true"
+    fluxcd.io/tag.chart-image: 'regexp:^(1\.[0-9]+\.[0-9]+-12-minimal)$'
 spec:
   releaseName: node-red
+  rollback:
+    enable: true
   chart:
     repository: https://kubernetes-charts.storage.googleapis.com/
     name: node-red

--- a/default/pihole/pihole.yaml
+++ b/default/pihole/pihole.yaml
@@ -1,15 +1,17 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: pihole
   namespace: default
   annotations:
     fluxcd.io/ignore: false
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.chart-image: 'regexp:^(4\.[0-9]+\.[0-9]+(-[0-9]+)?)$'
+    fluxcd.io/automated: "true"
+    fluxcd.io/tag.chart-image: 'regexp:^(4\.[0-9]+\.[0-9]+(-[0-9]+)?)$'
 spec:
   releaseName: pihole
+  rollback:
+    enable: true
   chart:
     git: https://github.com/billimek/pihole-kubernetes
     ref: integration

--- a/default/plex/plex.yaml
+++ b/default/plex/plex.yaml
@@ -1,15 +1,17 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: kube-plex
   namespace: default
   annotations:
     fluxcd.io/ignore: false
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.chart-image: 'regexp:^(1\.[0-9]+\.[0-9]+\.[0-9]+-.*)$'
+    fluxcd.io/automated: "true"
+    fluxcd.io/tag.chart-image: 'regexp:^(1\.[0-9]+\.[0-9]+\.[0-9]+-.*)$'
 spec:
   releaseName: kube-plex
+  rollback:
+    enable: true
   chart:
     git: https://github.com/munnerz/kube-plex
     ref: master

--- a/default/rabbitmq/rabbitmq.yaml
+++ b/default/rabbitmq/rabbitmq.yaml
@@ -1,13 +1,13 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: rabbitmq-ha
   namespace: default
   annotations:
     fluxcd.io/ignore: false
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.chart-image: 'regexp:^(3\.[0-9]+\.[0-9]+-alpine)$'
+    fluxcd.io/automated: "true"
+    fluxcd.io/tag.chart-image: 'regexp:^(3\.[0-9]+\.[0-9]+-alpine)$'
 spec:
   releaseName: rabbitmq-ha
   chart:

--- a/default/unifi/unifi.yaml
+++ b/default/unifi/unifi.yaml
@@ -1,15 +1,17 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: unifi
   namespace: default
   annotations:
     fluxcd.io/ignore: false
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.chart-image: 'regexp:^(5\.[0-9][0-9]\.[0-9]+)$'
+    fluxcd.io/automated: "true"
+    fluxcd.io/tag.chart-image: 'regexp:^(5\.[0-9][0-9]\.[0-9]+)$'
 spec:
   releaseName: unifi
+  rollback:
+    enable: true
   chart:
     repository: https://kubernetes-charts.storage.googleapis.com/
     name: unifi

--- a/flux/flux/flux-values.yaml
+++ b/flux/flux/flux-values.yaml
@@ -1,6 +1,5 @@
 helmOperator:
-  create: true
-  createCRD: true
+  create: false
 git:
   url: "git@github.com:billimek/k3s-gitops"
 registry:

--- a/flux/flux/flux.yaml
+++ b/flux/flux/flux.yaml
@@ -1,38 +1,18 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: flux
   namespace: flux
   annotations:
-    flux.weave.works/automated: "false"
-    flux.weave.works/tag.chart-image: semver:~1.14
+    fluxcd.io/automated: "false"
+    fluxcd.io/tag.chart-image: semver:~1.14
 spec:
   releaseName: flux
   chart:
     repository: https://charts.fluxcd.io/
     name: flux
-    version: 0.14.0
-  values:
-    image:
-      repository: docker.io/fluxcd/flux
-      tag: 1.14.1
-    helmOperator:
-      create: true
-      createCRD: true
-    git:
-      url: "git@github.com:billimek/k3s-gitops"
-    registry:
-      rps: 1
-      burst: 1
-    memcached:
-      tolerations:
-      - key: "arm"
-        operator: "Exists"
-    additionalArgs:
-    - --connect=ws://fluxcloud
-    prometheus:
-      enabled: true
-    syncGarbageCollection:
-      enabled: true
-      dry: false
+    version: 0.15.0
+  valuesFrom:
+  - externalSourceRef:
+      url: https://raw.githubusercontent.com/billimek/k3s-gitops/master/flux/flux/flux-values.yaml

--- a/flux/helm-operator/flux-helm-operator-values.yaml
+++ b/flux/helm-operator/flux-helm-operator-values.yaml
@@ -1,0 +1,8 @@
+createCRD: true
+git:
+  ssh:
+    secretName: flux-git-deploy
+chartsSyncInterval: "10m"
+statusUpdateInterval: "10m"
+prometheus:
+  enabled: true

--- a/flux/helm-operator/helm-operator.yaml
+++ b/flux/helm-operator/helm-operator.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: helm-operator
+  namespace: flux
+spec:
+  releaseName: helm-operator
+  chart:
+    repository: https://charts.fluxcd.io/
+    name: helm-operator
+    version: 0.2.0
+  valuesFrom:
+  - externalSourceRef:
+      url: https://raw.githubusercontent.com/billimek/k3s-gitops/master/flux/flux/flux-helm-operator-values.yaml

--- a/kube-system/cert-manager/cert-manager-chart.yaml
+++ b/kube-system/cert-manager/cert-manager-chart.yaml
@@ -1,14 +1,16 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: cert-manager
   namespace: kube-system
   annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.chart-image: semver:~v0.
+    fluxcd.io/automated: "true"
+    fluxcd.io/tag.chart-image: semver:~v0.
 spec:
   releaseName: cert-manager
+  rollback:
+    enable: true
   chart:
     repository: https://charts.jetstack.io/
     name: cert-manager

--- a/kube-system/descheduler/descheduler.yaml
+++ b/kube-system/descheduler/descheduler.yaml
@@ -1,13 +1,15 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: descheduler
   namespace: kube-system
   annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.chart-image: semver:~0.2
+    fluxcd.io/automated: "true"
+    fluxcd.io/tag.chart-image: semver:~0.2
 spec:
   releaseName: descheduler
+  rollback:
+    enable: true
   chart:
     repository: https://raw.githubusercontent.com/komljen/helm-charts/master/charts/
     name: descheduler

--- a/kube-system/kured/kured.yaml
+++ b/kube-system/kured/kured.yaml
@@ -1,11 +1,11 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: kured
   namespace: kube-system
   annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.chart-image: semver:~1
+    fluxcd.io/automated: "true"
+    fluxcd.io/tag.chart-image: semver:~1
 spec:
   releaseName: kured
   chart:
@@ -22,13 +22,13 @@ spec:
   valueFileSecrets:
   - name: "kured-helm-values"
 ---
-# apiVersion: flux.weave.works/v1beta1
+# apiVersion: fluxcd.io/v1beta1
 # kind: HelmRelease
 # metadata:
 #   name: kured-arm
 #   namespace: kube-system
 #   annotations:
-#     flux.weave.works/automated: "false"
+#     fluxcd.io/automated: "false"
 # spec:
 #   releaseName: kured-arm
 #   chart:

--- a/kube-system/metallb/metallb.yaml
+++ b/kube-system/metallb/metallb.yaml
@@ -1,10 +1,10 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: metallb
   namespace: kube-system
   annotations:
-    flux.weave.works/automated: "true"
+    fluxcd.io/automated: "true"
 spec:
   releaseName: metallb
   chart:

--- a/kube-system/metrics-server/metrics-server.yaml
+++ b/kube-system/metrics-server/metrics-server.yaml
@@ -1,14 +1,16 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: metrics-server
   namespace: kube-system
   annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.chart-image: semver:~v0.
+    fluxcd.io/automated: "true"
+    fluxcd.io/tag.chart-image: semver:~v0.
 spec:
   releaseName: metrics-server
+  rollback:
+    enable: true
   chart:
     repository: https://kubernetes-charts.storage.googleapis.com/
     name: metrics-server

--- a/kube-system/nfs-client-provisioner/nfs-client-provisioner.yaml
+++ b/kube-system/nfs-client-provisioner/nfs-client-provisioner.yaml
@@ -1,13 +1,15 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: nfs-client-provisioner
   namespace: kube-system
   annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.chart-image: semver:~v3.1
+    fluxcd.io/automated: "true"
+    fluxcd.io/tag.chart-image: semver:~v3.1
 spec:
   releaseName: nfs-client-provisioner
+  rollback:
+    enable: true
   chart:
     repository: https://kubernetes-charts.storage.googleapis.com/
     name: nfs-client-provisioner

--- a/kube-system/nginx/nginx.yaml
+++ b/kube-system/nginx/nginx.yaml
@@ -1,15 +1,17 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: nginx-ingress
   namespace: kube-system
   annotations:
     fluxcd.io/ignore: false
-    flux.weave.works/automated: "false"
-    flux.weave.works/tag.chart-image: semver:~0.
+    fluxcd.io/automated: "false"
+    fluxcd.io/tag.chart-image: semver:~0.
 spec:
   releaseName: nginx-ingress
+  rollback:
+    enable: true
   chart:
     repository: https://kubernetes-charts.storage.googleapis.com/
     name: nginx-ingress

--- a/kube-system/vault-secrets-operator/vault-secrets-operator.yaml
+++ b/kube-system/vault-secrets-operator/vault-secrets-operator.yaml
@@ -1,14 +1,16 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: vault-secrets-operator
   namespace: kube-system
   annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.chart-image: semver:~1
+    fluxcd.io/automated: "true"
+    fluxcd.io/tag.chart-image: semver:~1
 spec:
   releaseName: vault-secrets-operator
+  rollback:
+    enable: true
   chart:
     repository: https://ricoberger.github.io/helm-charts
     name: vault-secrets-operator

--- a/kube-system/vault/vault.yaml
+++ b/kube-system/vault/vault.yaml
@@ -1,4 +1,4 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: vault

--- a/logs/loki/loki.yaml
+++ b/logs/loki/loki.yaml
@@ -1,14 +1,14 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: loki
   namespace: logs
   annotations:
     fluxcd.io/ignore: true
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.loki: semver:~v0
-    flux.weave.works/tag.promtail: semver:~v0
+    fluxcd.io/automated: "true"
+    fluxcd.io/tag.loki: semver:~v0
+    fluxcd.io/tag.promtail: semver:~v0
 spec:
   releaseName: loki
   chart:

--- a/monitoring/chronograf/chronograf.yaml
+++ b/monitoring/chronograf/chronograf.yaml
@@ -1,15 +1,17 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: chronograf
   namespace: monitoring
   annotations:
     fluxcd.io/ignore: true
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.chart-image: semver:~1.7
+    fluxcd.io/automated: "true"
+    fluxcd.io/tag.chart-image: semver:~1.7
 spec:
   releaseName: chronograf
+  rollback:
+    enable: true
   chart:
     repository: https://kubernetes-charts.storage.googleapis.com/
     name: chronograf

--- a/monitoring/comcast/comcast.yaml
+++ b/monitoring/comcast/comcast.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: comcast
@@ -8,6 +8,8 @@ metadata:
     fluxcd.io/ignore: true
 spec:
   releaseName: comcast
+  rollback:
+    enable: true
   chart:
     repository: https://billimek.com/billimek-charts/
     name: comcast

--- a/monitoring/influxdb/influxdb.yaml
+++ b/monitoring/influxdb/influxdb.yaml
@@ -1,15 +1,17 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: influxdb
   namespace: monitoring
   annotations:
     fluxcd.io/ignore: false
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.chart-image: 'regexp:^(1\.[0-9]+\.[0-9]+)$'
+    fluxcd.io/automated: "true"
+    fluxcd.io/tag.chart-image: 'regexp:^(1\.[0-9]+\.[0-9]+)$'
 spec:
   releaseName: influxdb
+  rollback:
+    enable: true
   chart:
     repository: https://kubernetes-charts.storage.googleapis.com/
     name: influxdb

--- a/monitoring/modem-stats/modem-stats.yaml
+++ b/monitoring/modem-stats/modem-stats.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: modem-stats
@@ -8,6 +8,8 @@ metadata:
     fluxcd.io/ignore: true
 spec:
   releaseName: modem-stats
+  rollback:
+    enable: true
   chart:
     repository: https://billimek.com/billimek-charts/
     name: modem-stats

--- a/monitoring/prometheus-operator/prometheus-operator.yaml
+++ b/monitoring/prometheus-operator/prometheus-operator.yaml
@@ -1,13 +1,13 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: prometheus-operator
   namespace: monitoring
   annotations:
     fluxcd.io/ignore: false
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.grafana: semver:~6
+    fluxcd.io/automated: "true"
+    fluxcd.io/tag.grafana: semver:~6
 spec:
   releaseName: prometheus-operator
   chart:

--- a/monitoring/speedtest/speedtest.yaml
+++ b/monitoring/speedtest/speedtest.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: speedtest
@@ -8,6 +8,8 @@ metadata:
     fluxcd.io/ignore: true
 spec:
   releaseName: speedtest
+  rollback:
+    enable: true
   chart:
     repository: https://billimek.com/billimek-charts/
     name: speedtest

--- a/monitoring/uptimerobot/uptimerobot.yaml
+++ b/monitoring/uptimerobot/uptimerobot.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: uptimerobot
@@ -8,6 +8,8 @@ metadata:
     fluxcd.io/ignore: true
 spec:
   releaseName: uptimerobot
+  rollback:
+    enable: true
   chart:
     repository: https://billimek.com/billimek-charts/
     name: uptimerobot

--- a/rook-ceph/chart/rook-ceph-chart.yaml
+++ b/rook-ceph/chart/rook-ceph-chart.yaml
@@ -1,11 +1,11 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: rook-ceph
   namespace: rook-ceph
   annotations:
-    flux.weave.works/automated: "false"
+    fluxcd.io/automated: "false"
 spec:
   releaseName: rook-ceph
   chart:

--- a/setup/bootstrap-k3s.sh
+++ b/setup/bootstrap-k3s.sh
@@ -63,7 +63,8 @@ installFlux() {
   message "installing flux"
   # install flux
   helm repo add fluxcd https://charts.fluxcd.io
-  helm upgrade --install flux --values "$REPO_ROOT"/setup/flux-values.yaml --namespace flux fluxcd/flux
+  helm upgrade --install flux --values "$REPO_ROOT"/flux/flux/flux-values.yaml --namespace flux fluxcd/flux
+  helm upgrade --install helm-operator --values "$REPO_ROOT"/flux/helm-operator/flux-helm-operator-values.yaml --namespace flux fluxcd/helm-operator
 
   FLUX_READY=1
   while [ $FLUX_READY != 0 ]; do

--- a/velero/velero/velero.yaml
+++ b/velero/velero/velero.yaml
@@ -1,13 +1,13 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: velero
   namespace: velero
   annotations:
     fluxcd.io/ignore: false
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.chart-image: semver:~v1
+    fluxcd.io/automated: "true"
+    fluxcd.io/tag.chart-image: semver:~v1
 spec:
   releaseName: velero
   chart:


### PR DESCRIPTION
* replaced all references from `flux.weave.works` to `fluxcd.io`
* Bumped the flux apiVersion from v1beta1 to v1
* Upgraded to flux 1.15
* Seperate deployment of the helm-operator chart (which is no longer part of
the flux chart)
* flux and helm-operator chart values are each in a single file for
bootstrapping and follow-on mantinence